### PR TITLE
Consider counts of tokens in partial ordering

### DIFF
--- a/SCOPE.md
+++ b/SCOPE.md
@@ -45,4 +45,9 @@ skill_tree = topological_sort(meta)
     - Should this be unigram/bigram/...?
 * Sort the problem set in order of "A contained in B", that is, partial ordering of the entire problem set
 
-
+## Updates
+* [sk]: Update 4 Oct 16 - Happy with logic. Next step: get large and interesting data. Try:
+    * StackOverflow / Reddit for <Question, Snipper> pairs
+        - Research xkcd-related script to pull answers from SO
+    * CodeAcademy; Hour of Code : open datasets?
+    * Code.org: Mail for research related access 

--- a/data/hello/05_hello_world_twice.py
+++ b/data/hello/05_hello_world_twice.py
@@ -1,0 +1,2 @@
+print "Hello World!"
+print "Hello World Again!"

--- a/src/graph.py
+++ b/src/graph.py
@@ -43,7 +43,7 @@ class Graph(object):
 
     def add_vertices(self, vertex_data_list):
         vids = []
-        for item in data_list:
+        for item in vertex_data_list:
             vids.append(self.add_vertex(item))
         return vids
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,4 @@
 import ast
-import json
 import os
 
 from ast_visitors import CountingVisitor

--- a/src/program_meta.py
+++ b/src/program_meta.py
@@ -34,4 +34,10 @@ class ProgramMeta(object):
         return "<ProgramMeta #{}>  {}".format(self.pid, self.name)
 
     def __contains__(self, other):
-        return set(other.counts.keys()) <= set(self.counts.keys())
+        return (
+            set(other.counts.keys()) <= set(self.counts.keys()) and
+            all([
+                other.counts[key] <= self.counts[key]
+                for key in other.counts.keys()
+                ])
+            )


### PR DESCRIPTION
Completes minimal functionality from partial-ordering side. Ordering now enforces counts: i,e

`{"print": 1}` --> `{"print": 2}` but `{"print": 2}` -/-> `{"print": 1}`
